### PR TITLE
skip empty value/label to prevent wrong checksum(+32)

### DIFF
--- a/src/VEDirect.cpp
+++ b/src/VEDirect.cpp
@@ -55,6 +55,9 @@ bool VEDirect::HandleLine() {
     {
         byte checksum = 0;
         for (int x = 0; x < num_keywords; x++) {
+            if(strlen(recv_value[x]) == 0 || strlen(recv_label[x]) == 0) {
+                continue;
+            }
             char *v = recv_value[x];
             char *l = recv_label[x];
             while (*v) {


### PR DESCRIPTION
at least in the current version of 75/15 firmware (v164) there seems to be an empty line in the beginning of each frame, which results in wrong checksum calculation (always 32 instead of 0) - this change fixes the problem